### PR TITLE
Add support for symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
 		"psr-4": {"Markei\\FileSystemOperations\\": "src/Markei/FileSystemOperations"}
 	},
 	"require" : {
-		"symfony/filesystem": "^3|^4"
+		"symfony/filesystem": "^3|^4|^5"
 	}
 }


### PR DESCRIPTION
The code gives no reason to not support the Symfony 5 filesystem. Therefore, add support for Symfony 5 Filesystem to the composer.json